### PR TITLE
Fix inconsistent removal of trailing fwd slash across OS

### DIFF
--- a/R/dp_connect.R
+++ b/R/dp_connect.R
@@ -59,7 +59,7 @@ dp_connect.s3_board <- function(board_params, creds, ...) {
   # Register the board
   tryCatch({
     board <- pins::board_s3(
-      prefix = file.path(board_subdir),
+      prefix = board_subdir,
       bucket = board_params$bucket_name,
       region = board_params$region,
       access_key = key,


### PR DESCRIPTION
**Why**: Part of fix to address #38. Similar changes were done in all 3 core `daapr` pkgs: `dpi`, `dpdeploy`, `dpbuild`. For the fixes to address the underlying issue, all fixes will need to be incorporated.

**What**: Removed `file.path` calls when such calls impact AWS S3 path and instead explicitly passed the path with fwd slash as required by AWS S3 object path.

**Background**: `file.path` removes the trailing forward slash in a path in Windows OS, while it keeps it in Uinx. AWS S3 bucket paths require the trailing forward slash. As such, to make the behavior consistent across OS and inline with AWS S3 object path standards, we could remove the unnecessary `file.path` calls _when the path is used to specify S3 object storage_.